### PR TITLE
bpt_interface: use serial_for_url instead of Serial

### DIFF
--- a/bpt_interface/bpt_if.py
+++ b/bpt_interface/bpt_if.py
@@ -2,11 +2,11 @@ import serial
 
 PORT = '/dev/ttyACM0'
 BAUD = 115200
-dev = serial.Serial(PORT, BAUD, timeout=1)
+dev = serial.serial_for_url(PORT, BAUD, timeout=1)
 
 
 def open():
-    dev = serial.Serial(PORT, BAUD, timeout=1)
+    dev = serial.serial_for_url(PORT, BAUD, timeout=1)
     if(dev.isOpen() is False):
         dev.open()
 


### PR DESCRIPTION
This factory function enables usage of both local and remote ports.