### PR TITLE
typedef-gen: add shebang line and make executable

### DIFF
--- a/code_gen/typedef-gen.py
+++ b/code_gen/typedef-gen.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import json
 import argparse
 import pprint


### PR DESCRIPTION
Choose Python 3 as the only interpreter.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>