### PR TITLE
Adapt USB interface to the new uart_port structure

### DIFF
--- a/bluepill_tester/bluepill_tester/Inc/port_usb.h
+++ b/bluepill_tester/bluepill_tester/Inc/port_usb.h
@@ -16,6 +16,7 @@ typedef struct PORT_USB_TAG
 	uint16_t size;
 	uint16_t index;
 	uint8_t access;
+	uint8_t mode;
 }PORT_USB_t;
 
 error_t port_usb_init(PORT_USB_t *port_usb);

--- a/bluepill_tester/bluepill_tester/Src/main.c
+++ b/bluepill_tester/bluepill_tester/Src/main.c
@@ -136,7 +136,7 @@ int main(void) {
 	char if_uart_buf[UART_BUF_SIZE] = { 0 };
 	char if_usb_buf[UART_BUF_SIZE] = { 0 };
 
-	PORT_USB_t usb_if = {.str = if_usb_buf, .size = sizeof(if_usb_buf), .access = IF_ACCESS, .index = 0};
+	PORT_USB_t usb_if = {.str = if_usb_buf, .size = sizeof(if_usb_buf), .access = IF_ACCESS, .index = 0, .mode = MODE_REG};
 	PORT_UART_t uart_if = {.huart = &H_IF_UART, .str = if_uart_buf, .size = sizeof(if_uart_buf), .access = IF_ACCESS, .mode = MODE_REG};
 	PORT_UART_t uart_dut = {.huart = &H_DUT_UART, .str = dut_uart_buf, .size = sizeof(dut_uart_buf), .access = PERIPH_ACCESS, .mode = MODE_ECHO};
 	/* USER CODE END 1 */

--- a/bluepill_tester/bluepill_tester/Src/port_usb.c
+++ b/bluepill_tester/bluepill_tester/Src/port_usb.c
@@ -92,7 +92,7 @@ static error_t _rx_str(PORT_USB_t *port_usb) {
 	error_t err = ENOACTION;
 	if (port_usb->index > 0) {
 		if (str[port_usb->index - 1] == RX_END_CHAR) {
-			err = parse_command(str, port_usb->size, port_usb->access);
+			err = parse_input(port_usb->mode, str, port_usb->size, port_usb->access);
 			CDC_Transmit_FS((uint8_t*) str, strlen(str));
 		}
 	}


### PR DESCRIPTION
Add mode and invoke parse_input instead of parse_command.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>