### PR TITLE
Add routines for internal access to muliple registers

### DIFF
--- a/bluepill_tester/bluepill_tester/Inc/app.h
+++ b/bluepill_tester/bluepill_tester/Inc/app.h
@@ -13,7 +13,9 @@
 
 uint32_t get_reg_size();
 error_t read_reg(uint32_t index, uint8_t *data);
+error_t read_regs(uint32_t index, uint8_t *data, uint16_t size);
 error_t write_reg(uint32_t index, uint8_t data, uint8_t access);
+error_t write_regs(uint32_t index, uint8_t *data, uint16_t size, uint8_t access);
 
 error_t execute_reg_change();
 

--- a/bluepill_tester/bluepill_tester/Src/app.c
+++ b/bluepill_tester/bluepill_tester/Src/app.c
@@ -107,6 +107,18 @@ error_t read_reg(uint32_t index, uint8_t *data) {
 	return EUNKNOWN;
 }
 
+error_t read_regs(uint32_t index, uint8_t *data, uint16_t size) {
+    error_t errcode = EUNKNOWN;
+    for (int i = 0; i < size; i++) {
+        DIS_INT;
+        errcode = read_reg(index + i, &data[i]);
+        EN_INT;
+        if (errcode != EOK)
+            return errcode;
+    }
+    return errcode;
+}
+
 error_t write_reg(uint32_t index, uint8_t data, uint8_t access) {
 
 	if (index >= sizeof(reg)) {
@@ -120,3 +132,14 @@ error_t write_reg(uint32_t index, uint8_t data, uint8_t access) {
 	return EUNKNOWN;
 }
 
+error_t write_regs(uint32_t index, uint8_t *data, uint16_t size, uint8_t access) {
+    error_t errcode = EUNKNOWN;
+    for (int i = 0; i < size; i++) {
+        DIS_INT;
+        errcode = write_reg(index + i, data[i], access);
+        EN_INT;
+        if (errcode != EOK)
+            return errcode;
+    }
+    return errcode;
+}


### PR DESCRIPTION
Routines read_regs/write_regs allow access to multiple registers
via providing required size and a pointer to a byte array.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>