### PR TITLE
UART: setup pull-down option for CTS pin

### DIFF
--- a/bluepill_tester/bluepill_tester/Src/port.c
+++ b/bluepill_tester/bluepill_tester/Src/port.c
@@ -342,7 +342,7 @@ static void MX_GPIO_Init(void) {
 	/*Configure GPIO pin : DUT_CTS_Pin */
 	GPIO_InitStruct.Pin = DUT_CTS_Pin;
 	GPIO_InitStruct.Mode = GPIO_MODE_IT_RISING;
-	GPIO_InitStruct.Pull = GPIO_NOPULL;
+	GPIO_InitStruct.Pull = GPIO_PULLDOWN;
 	HAL_GPIO_Init(DUT_CTS_GPIO_Port, &GPIO_InitStruct);
 
 	/*Configure GPIO pin : DUT_RTS_Pin */


### PR DESCRIPTION
CTS pin is setup to generate an interrupt on the rising edge, so
setup pull-down option in order to prevent unwanted interrupts in
unconnected case.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>